### PR TITLE
Bug fix: H maps to ACT

### DIFF
--- a/model/src/main/java/org/nexml/model/impl/MolecularCharacterStateSetImpl.java
+++ b/model/src/main/java/org/nexml/model/impl/MolecularCharacterStateSetImpl.java
@@ -156,7 +156,7 @@ class MolecularCharacterStateSetImpl extends CharacterStateSetImpl{
         hSet.add(aState);
         hSet.add(cState);
         hSet.add(tState);
-        getCharacterStates().add(createUncertainCharacterState("H",dSet));
+        getCharacterStates().add(createUncertainCharacterState("H",hSet));
 
         // V => (A,C,G)
         Set<CharacterState> vSet = new HashSet<CharacterState>(3);
@@ -287,7 +287,7 @@ class MolecularCharacterStateSetImpl extends CharacterStateSetImpl{
         hSet.add(aState);
         hSet.add(cState);
         hSet.add(uState);
-        getCharacterStates().add(createUncertainCharacterState("H",dSet));
+        getCharacterStates().add(createUncertainCharacterState("H",hSet));
         
         // V => (A,C,G)
         Set<CharacterState> vSet = new HashSet<CharacterState>(3);


### PR DESCRIPTION
"dSet" here was intended to be "hSet" which is the
correctly composed ambiguity set for "H".
This bug causes the the
<characters ...>
  <format ... >
    <states ... >
      <uncertain_state_set symbol="H" >
element to contain the ambiguity codes for D (AGT)
rather than for H (ACT).